### PR TITLE
Added Buildx executable to agent image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM docker:dind as dind
 FROM jenkins/agent
 
 COPY --from=docker:dind /usr/local/bin/docker /usr/local/bin/
+COPY --from=docker:dind /usr/local/libexec/docker/cli-plugins/docker-buildx /usr/local/libexec/docker/cli-plugins/docker-compose /usr/local/libexec/docker/cli-plugins/
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
### Changements

- Ajout des binaires `docker-buildx` et `docker-compose` dans l’image car ils ne sont plus inclus dans le binaire `docker`.